### PR TITLE
Fix invalid .imp file generation on Windows

### DIFF
--- a/Package/PackageMaker.cs
+++ b/Package/PackageMaker.cs
@@ -112,7 +112,7 @@ namespace AssetstorePackageImprter
 			
 			var filePaths = Directory.GetFiles(path, "*.*", SearchOption.AllDirectories)
 				.Where(item => Path.GetExtension(item) != ".meta")
-					.Select(item => item.Replace(fullPath, "Assets"));
+					.Select(item => item.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).Replace(fullPath, "Assets"));
 			foreach( var filePath in filePaths ){
 				
 				var fileGuid = AssetDatabase.AssetPathToGUID(filePath);

--- a/Package/PackageMaker.cs
+++ b/Package/PackageMaker.cs
@@ -226,7 +226,7 @@ namespace AssetstorePackageImprter
 		{
 			var assetlist = new List<AssetData>();
 			
-			var files = Directory.GetFiles("Assets", "ImportPackages*.imp", SearchOption.AllDirectories);
+			var files = Directory.GetFiles("RequestPackages", "ImportPackages*.imp", SearchOption.AllDirectories);
 			foreach( var file in files ){
 				var text = File.ReadAllText(file);
 				var textReader = new System.IO.StringReader(text);

--- a/Package/PackageMaker.cs
+++ b/Package/PackageMaker.cs
@@ -226,7 +226,7 @@ namespace AssetstorePackageImprter
 		{
 			var assetlist = new List<AssetData>();
 			
-			var files = Directory.GetFiles("RequestPackages", "ImportPackages*.imp", SearchOption.AllDirectories);
+			var files = Directory.GetFiles(".", "ImportPackages*.imp", SearchOption.AllDirectories);
 			foreach( var file in files ){
 				var text = File.ReadAllText(file);
 				var textReader = new System.IO.StringReader(text);


### PR DESCRIPTION
`Directory.GetFiles(path, "*.*", SearchOption.AllDirectories)` returns full paths with mixed separator (`/` and `\`) like `C:/data/dev/unity/unity-trial-asset-homing-missile/Assets/Smart Homing Missile\Editor.meta` on Windows.
So I normalized file path by `Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)`.
I'm not sure this is right way or not, but file generation gets worked with this patch.


## My environment

* Windows 10, Unity 5.6.0p2
* Mac OS 10.10.5, Unity 5.5.2p1
  * It has been working well before/after patching this on Mac OS.


## Error message on the console

```
Invalid AssetDatabase path: C:/data/dev/unity/unity-trial-asset-homing-missile/Assets/Smart Homing Missile\ReadMe.txt. Use path relative to the project folder.
UnityEditor.AssetDatabase:AssetPathToGUID(String)
AssetstorePackageImprter.PackageMaker:Load(String) (at Assets/AssetRequest/Editor/PackageMaker.cs:118)
AssetstorePackageImprter.PackageMaker:OnGUI() (at Assets/AssetRequest/Editor/PackageMaker.cs:65)
UnityEditor.DockArea:OnGUI()
```

プルリクは英語で書いた方が良いと聞いた事があり、無理して英語で書きましたが、何言ってるか分からなかったらすいません。
エラーメッセージにあるファイルパスの様に、区切り文字が混ざることが原因で、生成された.impファイルにGUIDが含まれませんでした。
正直なところ、何故区切り文字が混ざってしまうのかや、この修正が本当に正しい対応なのかは、分かっていません。
調べておそらくこうかなと思う修正にはしましたが、違っている様なら遠慮なく閉じちゃってください。